### PR TITLE
fix the received object order

### DIFF
--- a/configs/ssd300_mobilenetv1.json
+++ b/configs/ssd300_mobilenetv1.json
@@ -1,6 +1,6 @@
 {
     "model": {
-        "name": "ssd300_mobilenetv1",
+        "name": "ssd_mobilenetv1",
         "input_size": 300,
         "l2_regularization": 0.0005,
         "kernel_initializer": "he_normal",

--- a/test.py
+++ b/test.py
@@ -39,7 +39,7 @@ input_size = config["model"]["input_size"]
 model_config = config["model"]
 
 if model_config["name"] == "ssd_mobilenetv2":
-    model, label_maps, process_input_fn = inference_utils.inference_ssd_mobilenetv2(
+    model, process_input_fn, label_maps = inference_utils.inference_ssd_mobilenetv2(
         config, args)
 elif model_config["name"] == "ssd_vgg16":
     model, process_input_fn, label_maps = inference_utils.ssd_vgg16(config, args)


### PR DESCRIPTION
The test.py parameter order is fixed in order to make mobilenet-ssd test script work.